### PR TITLE
Update to use dart sass instead of node sass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@flickerbox/build",
-  "version": "20.1.0",
+  "version": "20.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flickerbox/build",
-  "version": "20.1.0",
+  "version": "20.1.1",
   "description": "Flickerbox build module makes it easy to run webpack, babel, postcss, and more for a quality static resource build for your JS and CSS site assets.",
   "main": "index.js",
   "bin": {
@@ -68,8 +68,6 @@
     "html-webpack-plugin": "^3.2.0",
     "ignore-assets-webpack-plugin": "^2.0.1",
     "import-glob-loader": "1.1.0",
-    "node-sass": "^4.13.1",
-    "node-sass-glob-importer": "^5.3.2",
     "path": "^0.12.7",
     "postcss-cli": "^7.1.0",
     "postcss-loader": "^3.0.0",
@@ -90,7 +88,6 @@
     "webpack-cli": "^3.3.10",
     "webpack-dashboard": "^3.2.0",
     "webpack-dev-server": "^3.10.1",
-    "webpack-import-glob": "^2.0.0",
     "webpack-merge": "4.2.2",
     "webpack-notifier": "^1.8.0"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const babelConfig = require('./babel.config')
 const dashboard = require('webpack-dashboard/plugin')
-const globImporter = require('node-sass-glob-importer')
 const ignoreAssetsPlugin = require('ignore-assets-webpack-plugin')
 const notifier = require('webpack-notifier')
 const path = require('path')
@@ -84,9 +83,11 @@ module.exports = {
               sourceMap: ('development' === environment),
               sassOptions: {
                 precision: 10,
-                importer: globImporter()
               }
             }
+          },
+          {
+            loader: 'import-glob-loader',
           },
         ]
       },
@@ -126,7 +127,7 @@ module.exports = {
           }
         }]
       },
-    ]
+    ],
   },
 
 };


### PR DESCRIPTION
This updates the build to use dart sass instead of node sass. I guess we had the packages already included but webpack was opting for node sass instead.